### PR TITLE
BOLT12 fixes

### DIFF
--- a/electrum/bolt12.py
+++ b/electrum/bolt12.py
@@ -182,14 +182,22 @@ def to_lnaddr(data: dict) -> LnAddr:
     # NOTE: CLN puts the real node_id here, which is defeats the whole purpose of blinded paths
     # also, this should not be used as routing destination in payments (introduction point in set of blinded paths
     # must be used instead
-    pubkey = data.get('invoice_node_id').get('node_id')
+    for required in ('invoice_node_id', 'invoice_created_at', 'invoice_payment_hash'):
+        if not isinstance(data.get(required), dict):
+            raise Bolt12InvoiceError(f'malformed bolt12 invoice: missing required field {required!r}')
+    try:
+        pubkey = data['invoice_node_id']['node_id']
+        timestamp = data['invoice_created_at']['timestamp']
+        payment_hash = data['invoice_payment_hash']['payment_hash']
+    except KeyError as e:
+        raise Bolt12InvoiceError(f'malformed bolt12 invoice: missing inner field {e!r}') from e
 
     class WrappedBytesKey:
         serialize = lambda: pubkey
     addr.pubkey = WrappedBytesKey
     addr.net = net
-    addr.date = data.get('invoice_created_at').get('timestamp')
-    addr.paymenthash = data.get('invoice_payment_hash').get('payment_hash')
+    addr.date = timestamp
+    addr.paymenthash = payment_hash
     addr.payment_secret = b'\x00' * 32  # Note: payment secret is not needed, recipient can use path_id in encrypted_recipient_data
     msat = data.get('invoice_amount', {}).get('msat', None)
     if msat is not None:

--- a/electrum/bolt12.py
+++ b/electrum/bolt12.py
@@ -194,8 +194,12 @@ def to_lnaddr(data: dict) -> LnAddr:
     msat = data.get('invoice_amount', {}).get('msat', None)
     if msat is not None:
         addr.amount = Decimal(msat) / COIN / 1000
-    fallbacks = data.get('invoice_fallbacks', [])
-    fallbacks = list(filter(lambda x: x['version'] <= 16 and 2 <= len(x['address'] <= 40), fallbacks))
+    fallbacks = data.get('invoice_fallbacks', {}).get('fallbacks', [])
+    # `version` is decoded as a 1-byte `bytes` object by the lnmsg subtype parser
+    fallbacks = [
+        fb for fb in fallbacks
+        if fb['version'][0] <= 16 and 2 <= len(fb['address']) <= 40
+    ]
     if fallbacks:
         addr.tags.append(('f', fallbacks[0]))
     exp = data.get('invoice_relative_expiry', {}).get('seconds_from_creation', 0)

--- a/electrum/lnpeer.py
+++ b/electrum/lnpeer.py
@@ -3310,7 +3310,7 @@ class Peer(Logger, EventListener):
             blinding: bytes = None,
             is_trampoline: bool = False) -> ProcessedOnionPacket:
         onion_hash = onion_packet.onion_hash
-        cache_key = sha256(onion_hash + payment_hash + bytes([is_trampoline]))  # type: ignore
+        cache_key = sha256(onion_hash + payment_hash + bytes([is_trampoline]) + (blinding or b''))  # type: ignore
         if cached_onion := self._processed_onion_cache.get(cache_key):
             return cached_onion
 

--- a/electrum/lnpeer.py
+++ b/electrum/lnpeer.py
@@ -2129,15 +2129,21 @@ class Peer(Logger, EventListener):
         if htlc.blinding:  # payment over blinded path
             # spec: MUST return an error if the payload contains other tlv fields than encrypted_recipient_data,
             # current_path_key, amt_to_forward, outgoing_cltv_value and total_amount_msat.
-            assert all(x in ['encrypted_recipient_data', 'current_blinding_point', 'amt_to_forward', 'outgoing_cltv_value', 'total_amount_msat']
-                       for x in processed_onion.hop_data.payload.keys())
+            allowed_payload_keys = {
+                'encrypted_recipient_data', 'current_blinding_point',
+                'amt_to_forward', 'outgoing_cltv_value', 'total_amount_msat',
+            }
+            if not all(x in allowed_payload_keys for x in processed_onion.hop_data.payload.keys()):
+                log_fail_reason(f"unexpected tlv fields in blinded payload")
+                raise exc_incorrect_or_unknown_pd
             recipient_data = processed_onion.blinded_path_recipient_data
             path_id = recipient_data.get('path_id', {}).get('data')
             if not path_id:
                 log_fail_reason(f"'path_id' missing in recipient_data")
                 raise exc_incorrect_or_unknown_pd
 
-            if path_id not in self.lnworker._pathids[htlc.payment_hash]:
+            known_path_ids = self.lnworker._pathids.get(htlc.payment_hash)
+            if not known_path_ids or path_id not in known_path_ids:
                 log_fail_reason(f"unknown path_id for payment_hash")
                 raise exc_incorrect_or_unknown_pd
 

--- a/electrum/wallet_db.py
+++ b/electrum/wallet_db.py
@@ -69,7 +69,7 @@ class WalletUnfinished(WalletFileException):
 # seed_version is now used for the version of the wallet file
 OLD_SEED_VERSION = 4        # electrum versions < 2.0
 NEW_SEED_VERSION = 11       # electrum versions >= 2.0
-FINAL_SEED_VERSION = 66     # electrum >= 2.7 will set this to prevent
+FINAL_SEED_VERSION = 67     # electrum >= 2.7 will set this to prevent
                             # old versions from overwriting new format
 
 
@@ -238,6 +238,7 @@ class WalletDBUpgrader(Logger):
         self._convert_version_64()
         self._convert_version_65()
         self._convert_version_66()
+        self._convert_version_67()
         self.put('seed_version', FINAL_SEED_VERSION)  # just to be sure
 
     def _convert_wallet_type(self):
@@ -1331,6 +1332,16 @@ class WalletDBUpgrader(Logger):
 
         self.data['lightning_payments'] = new_payment_infos
         self.data['seed_version'] = 66
+
+    def _convert_version_67(self):
+        """UpdateAddHtlc storage tuple gained a trailing 'blinding' field for BOLT12 route-blinding.
+        Existing 5-tuples remain readable thanks to the default arg in UpdateAddHtlc.from_tuple, but
+        the version bump prevents older clients (which only accept 5-tuples) from silently opening
+        wallets that may now contain 6-tuple entries.
+        """
+        if not self._is_upgrade_method_needed(66, 66):
+            return
+        self.data['seed_version'] = 67
 
     def _convert_imported(self):
         if not self._is_upgrade_method_needed(0, 13):

--- a/tests/regtest/regtest.sh
+++ b/tests/regtest/regtest.sh
@@ -726,7 +726,6 @@ if [[ $1 == "watchtower" ]]; then
 fi
 
 if [[ $1 == "bolt12" ]]; then
-#    $carol enable_htlc_settle false
     bob_node=$($bob nodeid)
     wait_for_balance carol 1
     echo "alice and carol open channels with bob"

--- a/tests/test_bolt12.py
+++ b/tests/test_bolt12.py
@@ -353,6 +353,43 @@ class TestBolt12(ElectrumTestCase):
         }, signing_key)
         decode_invoice(invoice_tlv)
 
+    def test_to_lnaddr_with_fallbacks(self):
+        # regression: invoice_fallbacks subtype is a dict {'fallbacks': [..]}, and
+        # subtype 'version' is a 1-byte 'bytes' object, not an int.
+        signing_pubkey = privkey_to_pubkey(
+            bfh('4141414141414141414141414141414141414141414141414141414141414141'))
+        payment_hash = bytes(32)
+        invoice_data = {
+            'invoice_node_id': {'node_id': signing_pubkey},
+            'invoice_created_at': {'timestamp': 1700000000},
+            'invoice_payment_hash': {'payment_hash': payment_hash},
+            'invoice_amount': {'msat': 1234},
+            'invoice_relative_expiry': {'seconds_from_creation': 3600},
+            'offer_description': {'description': 'with fallbacks'},
+            'invoice_features': {'features': b'\x00'},
+            'invoice_fallbacks': {'fallbacks': [
+                {'version': b'\x00', 'address': b'\x01' * 20},  # accepted
+                {'version': b'\xff', 'address': b'\x01' * 20},  # rejected: version>16
+                {'version': b'\x00', 'address': b'\x01'},       # rejected: addr too short
+            ]},
+        }
+        addr = bolt12.to_lnaddr(invoice_data)
+        fallback_tags = [t for t in addr.tags if t[0] == 'f']
+        self.assertEqual(len(fallback_tags), 1)
+        self.assertEqual(fallback_tags[0][1]['version'], b'\x00')
+
+    def test_to_lnaddr_no_fallbacks(self):
+        signing_pubkey = privkey_to_pubkey(
+            bfh('4141414141414141414141414141414141414141414141414141414141414141'))
+        invoice_data = {
+            'invoice_node_id': {'node_id': signing_pubkey},
+            'invoice_created_at': {'timestamp': 1700000000},
+            'invoice_payment_hash': {'payment_hash': bytes(32)},
+            'invoice_amount': {'msat': 1234},
+        }
+        addr = bolt12.to_lnaddr(invoice_data)
+        self.assertEqual([t for t in addr.tags if t[0] == 'f'], [])
+
     def test_serde_complex_fields(self):
         payer_key = bfh('4141414141414141414141414141414141414141414141414141414141414141')
 


### PR DESCRIPTION
Some fixes/improvements for https://github.com/spesmilo/electrum/pull/10110 

- `bolt12.py::to_lnaddr` would have been unreachable without raising on any invoice carrying `invoice_fallbacks` (commit df8366bc0).
- `lnpeer.py` blinded final-hop handling crashed with `AssertionError`/`KeyError` on malformed or spurious HTLCs instead of returning the spec-mandated onion failure (commit 7c26c5b7c).
- `UpdateAddHtlc` storage gained a 6th field without a wallet-db version bump; bumped `FINAL_SEED_VERSION` to 67 (commit 7425e129d).
- `to_lnaddr` raised non-descriptive `AttributeError` on malformed invoices; now `Bolt12InvoiceError` (commit fd19abbde).
- `_processed_onion_cache` key omitted `blinding`, allowing cache collisions across distinct blinded paths for the same `payment_hash`; key now includes it (commit a8d64d98a).

End-to-end regtest `test_bolt12` passes (Alice -> Bob -> Carol BOLT12 payment over a blinded path).

`BOLT12_INVOICE_PREFIX` storage hack would benefit from documentation and a unit test confirming round-trip.